### PR TITLE
fix: ensure Reality privateKey generated reliably

### DIFF
--- a/scripts/install_mobile_reality.sh
+++ b/scripts/install_mobile_reality.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 info()  { echo -e "\e[32m[INFO]\e[0m $*"; }
 warn()  { echo -e "\e[33m[WARN]\e[0m $*"; }
@@ -9,22 +10,51 @@ req_root(){ [[ $EUID -eq 0 ]] || { err "Run as root"; exit 1; }; }
 install_xray(){
   if command -v xray >/dev/null 2>&1; then info "xray already installed"; return; fi
   info "Installing xray-core"; bash -c "$(curl -fsSL https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install
+  hash -r
 }
 
-free_port(){ local p=$1; ss -tuln | awk '{print $5}' | grep -q ":$p$" && return 1 || return 0; }
-select_port(){ local p=8443; while ! free_port "$p"; do p=$((p+1)); done; echo "$p"; }
+free_port(){ local p=$1; ss -tuln | awk '{print $5}' | sed 's/.*://g' | awk -F']' '{print $NF}' | grep -qx "$p" && return 1 || return 0; }
+select_port(){ local p=${1:-8443}; while ! free_port "$p"; do p=$((p+1)); done; echo "$p"; }
+
+generate_reality_keys(){
+  local XRAY_BIN out
+  XRAY_BIN=$(command -v xray || echo /usr/local/bin/xray)
+  if [[ ! -x "$XRAY_BIN" ]]; then err "xray binary not found"; exit 1; fi
+  out="$($XRAY_BIN x25519 2>/dev/null || true)"
+  PRIV=$(printf '%s\n' "$out" | sed -n 's/^Private key: \(.*\)$/\1/p')
+  PUB=$(printf '%s\n' "$out"  | sed -n 's/^Public key: \(.*\)$/\1/p')
+  # compatibility patterns
+  [[ -n "${PRIV:-}" && -n "${PUB:-}" ]] || {
+    PRIV=$(printf '%s\n' "$out" | sed -n 's/^Private\([Kk]ey\)\?: \(.*\)$/\2/p')
+    PUB=$(printf '%s\n' "$out"  | sed -n 's/^Public\([Kk]ey\)\?: \(.*\)$/\2/p')
+  }
+  # fallback to sing-box if available
+  if [[ -z "${PRIV:-}" || -z "${PUB:-}" ]]; then
+    if command -v sing-box >/dev/null 2>&1; then
+      out="$(sing-box generate reality-keypair 2>/dev/null || true)"
+      PRIV=$(printf '%s\n' "$out" | sed -n 's/^PrivateKey: \(.*\)$/\1/p')
+      PUB=$(printf '%s\n' "$out"  | sed -n 's/^PublicKey: \(.*\)$/\1/p')
+    fi
+  fi
+  if [[ -z "${PRIV:-}" || -z "${PUB:-}" ]]; then
+    err "Failed to generate Reality keypair. Check xray installation."
+    exit 1
+  fi
+}
 
 main(){
   req_root; install_xray
-  local XRAY_BIN PORT SNI tmp PRIV PUB UUID SID
+  local XRAY_BIN PORT SNI UUID SID
   XRAY_BIN=$(command -v xray || echo /usr/local/bin/xray)
+
   read -rp "SNI (default sun6-21.userapi.com): " SNI || true; SNI=${SNI:-sun6-21.userapi.com}
   read -rp "Port (default auto starting at 8443): " PORT || true; PORT=${PORT:-}
-  [[ -z "$PORT" ]] && PORT=$(select_port)
+  [[ -z "$PORT" ]] && PORT=$(select_port 8443)
   info "Using port $PORT and SNI $SNI"
 
-  tmp=$(mktemp); $XRAY_BIN x25519 > "$tmp"; PRIV=$(awk '/Private key/{print $3}' "$tmp"); PUB=$(awk '/Public key/{print $3}' "$tmp"); rm -f "$tmp"
-  UUID=$(cat /proc/sys/kernel/random/uuid); SID=ffffffffff
+  generate_reality_keys
+  UUID=$(cat /proc/sys/kernel/random/uuid)
+  SID=ffffffffff
 
   install -d -m0755 /etc/xray /var/log/xray
   cat > "/etc/xray/xray-reality-${PORT}.json" <<JSON


### PR DESCRIPTION
- Add generate_reality_keys() with xray + sing-box fallback\n- Validate and fail if keypair empty\n- Harden PATH and port detection\n- No changes to runtime defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized port detection and selection with customizable defaults (8443).
  * Strengthened Reality key pair generation with enhanced fallback mechanisms for better reliability.
  * Improved shell environment configuration to ensure proper binary discovery during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->